### PR TITLE
Add landing page with email counter

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>AI Podcast Generator</title>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Montserrat:wght@400;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header class="hero">
+        <h1>AI Podcast Generator</h1>
+        <p>Podcasts diarios y personalizados en menos de 5 minutos.</p>
+        <div class="cta">
+            <input type="email" id="email" placeholder="Tu email" required>
+            <select id="categories" multiple>
+                <option value="marketing">Marketing</option>
+                <option value="tech">Tech</option>
+                <option value="cultura">Cultura</option>
+                <option value="finanzas">Finanzas</option>
+                <option value="deportes">Deportes</option>
+                <option value="salud">Salud</option>
+                <option value="arte">Arte</option>
+            </select>
+            <button id="subscribe">Quiero mi podcast a medida</button>
+            <p id="message"></p>
+            <p class="counter">Interesados: <span id="count">0</span></p>
+        </div>
+    </header>
+    <section class="features">
+        <h2>Características de Performance</h2>
+        <ul>
+            <li>Ajusta la profundidad del contenido: titulares breves o análisis profundos.</li>
+            <li>Fuentes claras y confiables en cada episodio.</li>
+            <li>Episodios rápidos de 3 a 5 minutos.</li>
+        </ul>
+    </section>
+    <section class="delighters">
+        <h2>Delighters</h2>
+        <ul>
+            <li>Easter Eggs personalizados con tus artistas o eventos favoritos.</li>
+            <li>Episodios on‑demand cuando tú quieras.</li>
+            <li>Voz natural y cercana.</li>
+        </ul>
+    </section>
+    <section class="testimonials">
+        <blockquote>“Por fin un podcast a mi ritmo, sin perderme nada importante.”</blockquote>
+        <blockquote>“Me encanta que el resumen suene natural y siempre mencione algo personal.”</blockquote>
+    </section>
+    <footer>
+        <p>Tu email no será almacenado, solo sumará al contador de interesados.</p>
+    </footer>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,47 @@
+let interestedCount = parseInt(localStorage.getItem('interestedCount') || '0');
+const countEl = document.getElementById('count');
+const messageEl = document.getElementById('message');
+const emailSet = new Set();
+countEl.textContent = interestedCount;
+
+function animateCount(from, to) {
+    const duration = 500;
+    const start = performance.now();
+
+    function step(timestamp) {
+        const progress = Math.min((timestamp - start) / duration, 1);
+        const value = Math.floor(progress * (to - from) + from);
+        countEl.textContent = value;
+        if (progress < 1) {
+            requestAnimationFrame(step);
+        }
+    }
+    requestAnimationFrame(step);
+}
+
+document.getElementById('subscribe').addEventListener('click', () => {
+    const email = document.getElementById('email').value.trim();
+    const select = document.getElementById('categories');
+    const selected = Array.from(select.options)
+        .filter(o => o.selected)
+        .map(o => o.value);
+
+    if (!email) {
+        messageEl.textContent = 'Ingresa un email válido.';
+        return;
+    }
+
+    if (emailSet.has(email)) {
+        messageEl.textContent = '¡Ya te tenemos en cuenta!';
+        return;
+    }
+
+    emailSet.add(email);
+    interestedCount += 1;
+    localStorage.setItem('interestedCount', interestedCount);
+    const stored = JSON.parse(localStorage.getItem('categories') || '[]');
+    stored.push(selected);
+    localStorage.setItem('categories', JSON.stringify(stored));
+    animateCount(interestedCount - 1, interestedCount);
+    messageEl.textContent = '¡Gracias por tu interés! Te avisaremos cuando el producto esté listo.';
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,82 @@
+body {
+    font-family: 'Inter', sans-serif;
+    margin: 0;
+    background: #fff;
+    color: #333;
+}
+
+.hero {
+    text-align: center;
+    padding: 4rem 1rem;
+    background: linear-gradient(135deg, #e0f0ff, #ffffff);
+}
+
+h1 {
+    font-family: 'Montserrat', sans-serif;
+    font-size: 2.5rem;
+    margin-bottom: 0.5rem;
+}
+
+.cta {
+    margin-top: 1rem;
+}
+
+.cta input,
+.cta select {
+    padding: 0.5rem;
+    margin: 0.25rem;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+}
+
+#subscribe {
+    background: #007bff;
+    color: #fff;
+    border: none;
+    padding: 0.5rem 1rem;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: background 0.3s ease;
+}
+
+#subscribe:hover {
+    background: #0056b3;
+}
+
+.counter {
+    font-weight: 600;
+    margin-top: 0.5rem;
+}
+
+.features, .delighters, .testimonials {
+    padding: 2rem 1rem;
+    max-width: 800px;
+    margin: auto;
+}
+
+.features ul,
+.delighters ul {
+    list-style: disc;
+    padding-left: 1.5rem;
+    text-align: left;
+}
+
+.testimonials blockquote {
+    font-style: italic;
+    margin: 1rem 0;
+    border-left: 4px solid #007bff;
+    padding-left: 1rem;
+}
+
+footer {
+    text-align: center;
+    padding: 1rem;
+    background: #f5f5f5;
+    font-size: 0.9rem;
+}
+
+@media (max-width: 600px) {
+    h1 {
+        font-size: 1.8rem;
+    }
+}


### PR DESCRIPTION
## Summary
- build basic landing page for AI Podcast Generator
- style with blue gradients and responsive layout
- add client-side signup logic with animated counter

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68855c39c580832583b1749f9fb97e0a